### PR TITLE
Add routing to abstract each component into it's own 'page'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,6 @@
     "react/prefer-stateless-function": 0,
     "react/forbid-prop-types": 0,
     "function-paren-newline": 0,
-    "arrow-body-style": "never"
+    "arrow-body-style": 2
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,6 @@
     "react/prefer-stateless-function": 0,
     "react/forbid-prop-types": 0,
     "function-paren-newline": 0,
-    "arrow-body-style": 2
+    "arrow-body-style": "never"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": 0,
     "react/forbid-prop-types": 0,
-    "function-paren-newline": 0
+    "function-paren-newline": 0,
+    "arrow-body-style": 2
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4675,6 +4675,19 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "dev": true,
+      "requires": {
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4689,6 +4702,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
       "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
+    "hoist-non-react-statics": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -8416,6 +8435,35 @@
         }
       }
     },
+    "react-router": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
+      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+      "dev": true,
+      "requires": {
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.3.1",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
+      "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
+      "dev": true,
+      "requires": {
+        "history": "4.7.2",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "react-router": "4.2.0",
+        "warning": "3.0.0"
+      }
+    },
     "react-scripts": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.14.tgz",
@@ -8897,6 +8945,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
+      "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -9960,6 +10014,12 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
+      "dev": true
+    },
     "vanilla-framework": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/vanilla-framework/-/vanilla-framework-1.5.4.tgz",
@@ -10000,6 +10060,15 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.11"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
       }
     },
     "watch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4679,7 +4679,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
-      "dev": true,
       "requires": {
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
@@ -4706,8 +4705,7 @@
     "hoist-non-react-statics": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA=",
-      "dev": true
+      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -8439,7 +8437,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
       "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
-      "dev": true,
       "requires": {
         "history": "4.7.2",
         "hoist-non-react-statics": "2.3.1",
@@ -8454,7 +8451,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
       "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
-      "dev": true,
       "requires": {
         "history": "4.7.2",
         "invariant": "2.2.2",
@@ -8949,8 +8945,7 @@
     "resolve-pathname": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
-      "dev": true
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -10017,8 +10012,7 @@
     "value-equal": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
-      "dev": true
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vanilla-framework": {
       "version": "1.5.4",
@@ -10066,7 +10060,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0",
+    "react-router-dom": "^4.2.2",
     "react-test-renderer": "^16.0.0",
     "gh-pages": "^1.0.0",
     "vanilla-framework": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-scripts": "1.0.14"
+    "react-scripts": "1.0.14",
+    "react-router-dom": "^4.2.2"
   },
   "scripts": {
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
@@ -31,7 +32,6 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0",
-    "react-router-dom": "^4.2.2",
     "react-test-renderer": "^16.0.0",
     "gh-pages": "^1.0.0",
     "vanilla-framework": "^1.5.4"

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import './App.css';
 
 // Components
@@ -20,14 +20,12 @@ class App extends Component {
           <div className="col-12">
             <Header />
             <Aside />
-            <Router>
-              <main>
-                <Route exact path="/" component={Intro} />
-                <Route exact path="/cards" component={CardsExample} />
-                <Route exact path="/buttons" component={ButtonsExample} />
-                <Route exact path="/switches" component={SwitchesExample} />
-              </main>
-            </Router>
+            <main>
+              <Route exact path="/" component={Intro} />
+              <Route exact path="/cards" component={CardsExample} />
+              <Route exact path="/buttons" component={ButtonsExample} />
+              <Route exact path="/switches" component={SwitchesExample} />
+            </main>
           </div>
         </div>
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,90 +1,32 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Route } from 'react-router-dom';
 import './App.css';
 
 // Components
-import Button from '../Button/Button';
-import Card from '../Card/Card';
-import Switch from '../Switch/Switch';
+import Header from '../Header/Header';
+import Intro from '../Intro/Intro';
+
+import CardsExample from '../Card/CardsExample';
+import ButtonsExample from '../Button/ButtonsExample';
 
 class App extends Component {
-  constructor() {
-    super();
-    this.image = {
-      src: 'http://placekitten.com/g/64/64',
-      alt: 'Placeholder',
-    };
-  }
   render() {
     return (
       <div className="App">
-        <header id="navigation" className="p-navigation--light">
-          <div className="row">
-            <div className="p-navigation__banner">
-              <div className="p-navigation__logo">
-                <a className="p-navigation__link" href="/">
-                  <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
-                </a>
-              </div>
-            </div>
-          </div>
-        </header>
-        <div className="p-strip u-no-padding--bottom">
-          <div className="row">
-            <div className="col-12">
-              <p>
-              This is a simple implementation of Vanilla Framework using React.
-              </p>
-            </div>
-          </div>
-        </div>
-        <hr />
-        <div className="p-strip">
-          <div className="row">
-            <div className="col-6">
-              <h2>Buttons</h2>
-              <p><Button value="Base button 😶" /></p>
-              <p><Button value="Neutral button 😐" modifier="neutral" /></p>
-              <p><Button value="Brand button 💥" modifier="brand" /></p>
-              <p><Button value="Negative button 😡" modifier="negative" /></p>
-              <p><Button value="Positive button 😁" modifier="positive" /></p>
-            </div>
-          </div>
-        </div>
-        <hr />
-        <div className="p-strip">
-          <div className="row">
-            <div className="col-6">
-              <h2>Card</h2>
-              <Card
-                title="Card title"
-                image={this.image}
-              >
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
-              </Card>
-              <h2>Highlighted Card</h2>
-              <Card
-                modifier="highlighted"
-                title="Card title"
-                image={this.image}
-              >
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
-              </Card>
-            </div>
-          </div>
-        </div>
-        <hr />
-        <div className="p-strip">
-          <div className="row">
-            <div className="col-6">
-              <h2>Switch</h2>
-              <p><Switch label="Turn On/Off" /></p>
-            </div>
-          </div>
-        </div>
-        <hr />
+        <Header />
+        <main>
+          <Route exact path="/" component={Intro} />
+          <Route exact path="/cards" component={CardsExample} />
+          <Route exact path="/buttons" component={ButtonsExample} />
+        </main>
       </div>
     );
   }
 }
+
+App.contextTypes = {
+  router: PropTypes.object,
+};
 
 export default App;

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,7 +15,7 @@ import SwitchesExample from '../Switch/SwitchesExample';
 class App extends Component {
   render() {
     return (
-      <div className="App">
+      <div className="app">
         <Header />
         <Aside />
         <main>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -10,6 +10,7 @@ import Intro from '../Intro/Intro';
 
 import CardsExample from '../Card/CardsExample';
 import ButtonsExample from '../Button/ButtonsExample';
+import SwitchesExample from '../Switch/SwitchesExample';
 
 class App extends Component {
   render() {
@@ -23,6 +24,7 @@ class App extends Component {
               <Route exact path="/" component={Intro} />
               <Route exact path="/cards" component={CardsExample} />
               <Route exact path="/buttons" component={ButtonsExample} />
+              <Route exact path="/switches" component={SwitchesExample} />
             </main>
           </div>
         </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -18,14 +18,12 @@ class App extends Component {
       <div className="App">
         <Header />
         <Aside />
-        <Router>
-          <main>
-            <Route exact path="/" component={Intro} />
-            <Route exact path="/cards" component={CardsExample} />
-            <Route exact path="/buttons" component={ButtonsExample} />
-            <Route exact path="/switches" component={SwitchesExample} />
-          </main>
-        </Router>
+        <main>
+          <Route exact path="/" component={Intro} />
+          <Route exact path="/cards" component={CardsExample} />
+          <Route exact path="/buttons" component={ButtonsExample} />
+          <Route exact path="/switches" component={SwitchesExample} />
+        </main>
       </div>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,18 +16,16 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <div className="row">
-          <div className="col-12">
-            <Header />
-            <Aside />
-            <main>
-              <Route exact path="/" component={Intro} />
-              <Route exact path="/cards" component={CardsExample} />
-              <Route exact path="/buttons" component={ButtonsExample} />
-              <Route exact path="/switches" component={SwitchesExample} />
-            </main>
-          </div>
-        </div>
+        <Header />
+        <Aside />
+        <Router>
+          <main>
+            <Route exact path="/" component={Intro} />
+            <Route exact path="/cards" component={CardsExample} />
+            <Route exact path="/buttons" component={ButtonsExample} />
+            <Route exact path="/switches" component={SwitchesExample} />
+          </main>
+        </Router>
       </div>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 import './App.css';
 
 // Components
@@ -20,12 +20,14 @@ class App extends Component {
           <div className="col-12">
             <Header />
             <Aside />
-            <main>
-              <Route exact path="/" component={Intro} />
-              <Route exact path="/cards" component={CardsExample} />
-              <Route exact path="/buttons" component={ButtonsExample} />
-              <Route exact path="/switches" component={SwitchesExample} />
-            </main>
+            <Router>
+              <main>
+                <Route exact path="/" component={Intro} />
+                <Route exact path="/cards" component={CardsExample} />
+                <Route exact path="/buttons" component={ButtonsExample} />
+                <Route exact path="/switches" component={SwitchesExample} />
+              </main>
+            </Router>
           </div>
         </div>
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import './App.css';
 
 // Components
 import Header from '../Header/Header';
+import Aside from '../Aside/Aside';
 import Intro from '../Intro/Intro';
 
 import CardsExample from '../Card/CardsExample';
@@ -14,12 +15,17 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <Header />
-        <main>
-          <Route exact path="/" component={Intro} />
-          <Route exact path="/cards" component={CardsExample} />
-          <Route exact path="/buttons" component={ButtonsExample} />
-        </main>
+        <div className="row">
+          <div className="col-12">
+            <Header />
+            <Aside />
+            <main>
+              <Route exact path="/" component={Intro} />
+              <Route exact path="/cards" component={CardsExample} />
+              <Route exact path="/buttons" component={ButtonsExample} />
+            </main>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -6,9 +6,14 @@
 @include vf-p-grid-modifications;
 
 // Temp layout
+
+.app-logo {
+  padding: 0 1rem;
+}
+
 @supports (display: grid) {
 
-  .App {
+  .app {
     display: grid;
     width: 100%;
     grid-template-areas: "head head"
@@ -23,10 +28,13 @@
 
   aside {
     grid-area: nav;
+    border-right: 1px solid #ccc;
+    margin-right: 1rem;
   }
 
   main {
     grid-area: main;
+    padding-left: 1rem;
   }
 }
 

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -4,3 +4,20 @@
 @include vanilla-base;
 @include vf-p-grid;
 @include vf-p-grid-modifications;
+
+// Temp layout
+aside,
+main {
+  float: left;
+}
+
+aside {
+  width: calc(20% - 1rem);
+  border-right: 1px solid #ccc;
+  margin-right: 1rem;
+}
+
+main {
+  padding-left: 1rem;
+  width: 80%;
+}

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -6,18 +6,44 @@
 @include vf-p-grid-modifications;
 
 // Temp layout
-aside,
-main {
-  float: left;
+@supports (display: grid) {
+
+  .App {
+    display: grid;
+    width: 100%;
+    grid-template-areas: "head head"
+                         "nav  main";
+    grid-template-rows: 50px 1fr;
+    grid-template-columns: 150px 1fr;
+  }
+
+  header {
+    grid-area: head;
+  }
+
+  aside {
+    grid-area: nav;
+  }
+
+  main {
+    grid-area: main;
+  }
 }
 
-aside {
-  width: calc(20% - 1rem);
-  border-right: 1px solid #ccc;
-  margin-right: 1rem;
-}
+@supports not (display: grid) {
+  aside,
+  main {
+    float: left;
+  }
 
-main {
-  padding-left: 1rem;
-  width: 80%;
+  aside {
+    width: calc(20% - 1rem);
+    border-right: 1px solid #ccc;
+    margin-right: 1rem;
+  }
+
+  main {
+    padding-left: 1rem;
+    width: 80%;
+  }
 }

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(<Router><App /></Router>, div);
 });

--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -8,6 +8,7 @@ class Aside extends React.Component {
         <ul className="p-list">
           <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
           <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
+          <li><NavLink exact to="/switches" activeClassName="active">Switches</NavLink></li>
         </ul>
       </aside>
     );

--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -1,20 +1,23 @@
 import React from 'react';
-import { BrowserRouter as Router, NavLink } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { NavLink } from 'react-router-dom';
 
 class Aside extends React.Component {
   render() {
     return (
-      <Router>
-        <aside>
-          <ul className="p-list">
-            <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
-            <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
-            <li><NavLink exact to="/switches" activeClassName="active">Switches</NavLink></li>
-          </ul>
-        </aside>
-      </Router>
+      <aside>
+        <ul className="p-list">
+          <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
+          <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
+          <li><NavLink exact to="/switches" activeClassName="active">Switches</NavLink></li>
+        </ul>
+      </aside>
     );
   }
 }
+
+Aside.contextTypes = {
+  router: PropTypes.object,
+};
 
 export default Aside;

--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -1,16 +1,18 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { BrowserRouter as Router, NavLink } from 'react-router-dom';
 
 class Aside extends React.Component {
   render() {
     return (
-      <aside>
-        <ul className="p-list">
-          <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
-          <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
-          <li><NavLink exact to="/switches" activeClassName="active">Switches</NavLink></li>
-        </ul>
-      </aside>
+      <Router>
+        <aside>
+          <ul className="p-list">
+            <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
+            <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
+            <li><NavLink exact to="/switches" activeClassName="active">Switches</NavLink></li>
+          </ul>
+        </aside>
+      </Router>
     );
   }
 }

--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+class Aside extends React.Component {
+  render() {
+    return (
+      <aside>
+        <ul className="p-list">
+          <li><NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink></li>
+          <li><NavLink exact to="/cards" activeClassName="active">Cards</NavLink></li>
+        </ul>
+      </aside>
+    );
+  }
+}
+
+export default Aside;

--- a/src/components/Button/ButtonsExample.js
+++ b/src/components/Button/ButtonsExample.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Button from './Button'
+import Button from './Button';
 import './Button.css';
 
 class ButtonsExample extends React.Component {

--- a/src/components/Button/ButtonsExample.js
+++ b/src/components/Button/ButtonsExample.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button from './Button'
+import './Button.css';
+
+class ButtonsExample extends React.Component {
+  render() {
+    return (
+      <div>
+        <h2>Buttons</h2>
+        <p><Button value="Base button 😶" /></p>
+        <p><Button value="Neutral button 😐" modifier="neutral" /></p>
+        <p><Button value="Brand button 💥" modifier="brand" /></p>
+        <p><Button value="Negative button 😡" modifier="negative" /></p>
+        <p><Button value="Positive button 😁" modifier="positive" /></p>
+      </div>
+    );
+  }
+}
+
+Button.defaultProps = { modifier: 'base' };
+
+export default ButtonsExample;

--- a/src/components/Card/CardsExample.js
+++ b/src/components/Card/CardsExample.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import Card from './Card';
+
+class CardsExample extends React.Component {
+  constructor() {
+    super();
+    this.image = {
+      src: 'http://placekitten.com/g/64/64',
+      alt: 'Placeholder',
+    };
+  }
+  render() {
+    return (
+      <div>
+        <h2>Card</h2>
+        <Card
+          title="Card title"
+          image={this.image}
+        >
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+        </Card>
+        <h2>Highlighted Card</h2>
+        <Card
+          modifier="highlighted"
+          title="Card title"
+          image={this.image}
+        >
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+        </Card>
+      </div>
+    );
+  }
+}
+
+export default CardsExample;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,22 +4,20 @@ import { BrowserRouter as Router, Link } from 'react-router-dom';
 class Header extends React.Component {
   render() {
     return (
-      <div>
-        <header id="navigation" className="p-navigation--light">
-          <div className="row">
-            <div className="p-navigation__banner">
-              <div className="p-navigation__logo">
-                <Router>
-                  <Link className="p-navigation__link" to="/" href="/">
-                    <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
-                  </Link>
-                </Router>
-              </div>
+      <header id="navigation" className="p-navigation--light">
+        <div className="row">
+          <div className="p-navigation__banner">
+            <div className="p-navigation__logo">
+              <Router>
+                <Link className="p-navigation__link" to="/" href="/">
+                  <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
+                </Link>
+              </Router>
             </div>
           </div>
-        </header>
+        </div>
         <hr />
-      </div>
+      </header>
     );
   }
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, NavLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 class Header extends React.Component {
   render() {
@@ -16,9 +16,6 @@ class Header extends React.Component {
             </div>
           </div>
         </header>
-        <hr />
-        <NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink>
-        <NavLink exact to="/cards" activeClassName="active">Cards</NavLink>
         <hr />
       </div>
     );

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,15 +5,13 @@ class Header extends React.Component {
   render() {
     return (
       <header id="navigation" className="p-navigation--light">
-        <div className="row">
-          <div className="p-navigation__banner">
-            <div className="p-navigation__logo">
-              <Router>
-                <Link className="p-navigation__link" to="/" href="/">
-                  <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
-                </Link>
-              </Router>
-            </div>
+        <div className="p-navigation__banner">
+          <div className="p-navigation__logo">
+            <Router>
+              <Link className="p-navigation__link" to="/" href="/">
+                <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="app-logo" alt="logo" />
+              </Link>
+            </Router>
           </div>
         </div>
         <hr />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { BrowserRouter as Router, Link } from 'react-router-dom';
 
 class Header extends React.Component {
   render() {
@@ -9,9 +9,11 @@ class Header extends React.Component {
           <div className="row">
             <div className="p-navigation__banner">
               <div className="p-navigation__logo">
-                <Link className="p-navigation__link" to="/" href="/">
-                  <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
-                </Link>
+                <Router>
+                  <Link className="p-navigation__link" to="/" href="/">
+                    <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
+                  </Link>
+                </Router>
               </div>
             </div>
           </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link, NavLink } from 'react-router-dom';
+
+class Header extends React.Component {
+  render() {
+    return (
+      <div>
+        <header id="navigation" className="p-navigation--light">
+          <div className="row">
+            <div className="p-navigation__banner">
+              <div className="p-navigation__logo">
+                <Link className="p-navigation__link" to="/" href="/">
+                  <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" className="App-logo" alt="logo" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        </header>
+        <hr />
+        <NavLink exact to="/buttons" activeClassName="active">Buttons</NavLink>
+        <NavLink exact to="/cards" activeClassName="active">Cards</NavLink>
+        <hr />
+      </div>
+    );
+  }
+}
+
+export default Header;

--- a/src/components/Intro/Intro.js
+++ b/src/components/Intro/Intro.js
@@ -3,7 +3,10 @@ import React from 'react';
 class Intro extends React.Component {
   render() {
     return (
-      <h1>This is an implementation of Vanilla Framework in React.</h1>
+      <div>
+        <h1>Vanilla Framework (in React)</h1>
+        <p>This is an implementation of Vanilla Framework in React.</p>
+      </div>
     );
   }
 }

--- a/src/components/Intro/Intro.js
+++ b/src/components/Intro/Intro.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+class Intro extends React.Component {
+  render() {
+    return (
+      <h1>This is an implementation of Vanilla Framework in React.</h1>
+    );
+  }
+}
+
+export default Intro;

--- a/src/components/Switch/SwitchesExample.js
+++ b/src/components/Switch/SwitchesExample.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Switch from './Switch';
+
+class SwitchesExample extends React.Component {
+  render() {
+    return (
+      <div>
+        <Switch label="On/Off" />
+      </div>
+    );
+  }
+}
+
+export default SwitchesExample;

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,7 @@ import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';
 
 const Root = () => (
-  <Router>
-    <App />
-  </Router>
+  <App />
 );
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import './index.css';
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const Root = () => {
+  return(
+    <Router>
+      <App />
+    </Router>
+  );
+}
+
+
+ReactDOM.render(<Root />, document.getElementById('root'));
 registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import './index.css';
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';
 
 const Root = () => (
-  <App />
+  <Router>
+    <App />
+  </Router>
 );
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,11 @@ import './index.css';
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';
 
-const Root = () => {
-  return(
-    <Router>
-      <App />
-    </Router>
-  );
-}
+const Root = () => (
+  <Router>
+    <App />
+  </Router>
+);
 
 
 ReactDOM.render(<Root />, document.getElementById('root'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
 import './index.css';
 import App from './components/App/App';
 import registerServiceWorker from './registerServiceWorker';


### PR DESCRIPTION
## Done

Added [React Router](https://reacttraining.com/react-router/) so app can navigate between different "pages" to show different components

## Note

I have added a small bit of temporary CSS to create the sidebar layout, the aspiration is to implement the correct Vanilla docs layout but that is beyond the scope of this task.

## QA

- Pull code
- Run `npm run start`
- View http://localhost:3000/
- Click different patterns in the sidebar
- Run `npm run lint` - should be no errors
- Run `npm run test`-  should be no errors

Fixes: https://app.zenhub.com/workspace/o/ubuntudesign/vanilla-squad/issues/97